### PR TITLE
Update feed handeling

### DIFF
--- a/src/Store/emailListSlice.ts
+++ b/src/Store/emailListSlice.ts
@@ -556,9 +556,17 @@ export const refreshEmailFeed = (): AppThunk => async (dispatch, getState) => {
     if (response?.status === 200) {
       const { history } = response.data
       if (history) {
-        const { storageLabels } = getState().labels
+        const { loadedInbox, storageLabels } = getState().labels
         const sortedFeeds = handleHistoryObject({ history, storageLabels })
-        sortedFeeds.forEach((feed) => dispatch(loadEmailDetails(feed)))
+
+        // Skip the feed, if the feed hasn't loaded yet.
+        for (let i = 0; i < sortedFeeds.length; i += 1) {
+          for (let j = 0; j < loadedInbox.length; j += 1) {
+            if (sortedFeeds[i].labels.includes(loadedInbox[j][0])) {
+              dispatch(loadEmailDetails(sortedFeeds[i]))
+            }
+          }
+        }
       }
       const { data } = await userApi().fetchUser()
       dispatch(setProfile(data))

--- a/src/components/EmailList/EmailList.tsx
+++ b/src/components/EmailList/EmailList.tsx
@@ -77,7 +77,7 @@ const RenderEmailList = ({
             <GS.Base>
               {threads.map((email, index) => (
                 <div
-                  key={email.id}
+                  key={email?.id}
                   onFocus={() => setFocusedItemIndex(index)}
                   onMouseOver={() => setFocusedItemIndex(index)}
                   aria-hidden="true"
@@ -151,6 +151,8 @@ const EmailList = () => {
   const viewIndex = useAppSelector(selectViewIndex)
   const dispatch = useAppDispatch()
 
+  // If the box is empty, and the history feed is adding the item to the feed - there is no next page token and the feed is only that shallow item.
+
   useEffect(() => {
     let mounted = true
     let emailPromise: any = {}
@@ -207,10 +209,10 @@ const EmailList = () => {
     }
   }, [labelIds, window.location, viewIndex])
 
-  // Run a clean up function to ensure that the email detail values are always back to base.
+  // Run a clean up function to ensure that the email detail values are always back to base values.
   useEffect(() => {
     dispatch(resetValuesEmailDetail())
-  }, [])
+  }, [dispatch])
 
   const emailListIndex = useMemo(
     () => getEmailListIndex({ emailList, labelIds }),

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -194,7 +194,7 @@ const Search = () => {
                 nextPageToken: response.nextPageToken ?? null,
               }
               setSearchResults(newStateObject)
-              setLoadState(SEARCH_STATE.LOADED)
+              setLoadState(global.LOAD_STATE_MAP.loaded)
               return
             }
             if (searchResults && searchResults.threads.length > 0) {
@@ -203,7 +203,7 @@ const Search = () => {
                 nextPageToken: response.nextPageToken ?? null,
               }
               setSearchResults(newStateObject)
-              setLoadState(SEARCH_STATE.LOADED)
+              setLoadState(global.LOAD_STATE_MAP.loaded)
             }
           }
         })

--- a/src/utils/handleHistoryObject.ts
+++ b/src/utils/handleHistoryObject.ts
@@ -38,6 +38,7 @@ export default function handleHistoryObject({ history, storageLabels }: any) {
     const cleanHistoryArray = history.filter(
       (item) => Object.keys(item).length > 2
     )
+    // If item has been marked as read and is also archived, the item is coming up twice in the feed. Make sure that the end feed doesn't include these items for the labelsRemoved
     for (let i = 0; i < cleanHistoryArray.length; i += 1) {
       const item = cleanHistoryArray[i]
       if (Object.prototype.hasOwnProperty.call(item, 'labelsRemoved')) {
@@ -64,6 +65,20 @@ export default function handleHistoryObject({ history, storageLabels }: any) {
               restructureObject(item.labelsRemoved[0].message)
             )
           }
+        }
+        if (item.labelsRemoved[0].labelIds.includes(global.INBOX_LABEL)) {
+          const output = inboxFeed.threads.filter(
+            (filterItem) =>
+              filterItem.id !== item.labelsRemoved[0].message.threadId
+          )
+          inboxFeed.threads = output
+        }
+        if (item.labelsRemoved[0].labelIds.includes(toDoLabelId)) {
+          const output = todoFeed.threads.filter(
+            (filterItem) =>
+              filterItem.id !== item.labelsRemoved[0].message.threadId
+          )
+          todoFeed.threads = output
         }
       }
       if (Object.prototype.hasOwnProperty.call(item, 'labelsAdded')) {


### PR DESCRIPTION
1. Don't add items to the output feed for the History object, if the item has been marked as archived - but also happens to be marked as read on the same history refresh.
2. Don't load the feed items if the inbox hasn't been marked as loaded