### PR TITLE
Capping condition to limit unique user to 2 for selected mail removed, fix #1143

### DIFF
--- a/src/components/CommandPalette/Suggestions/ContextualItems.tsx
+++ b/src/components/CommandPalette/Suggestions/ContextualItems.tsx
@@ -74,7 +74,7 @@ export default function contextualItems({
         })
       )
     }
-    if (uniqueUsers.length > 1 && uniqueUsers.length < 3) {
+    if (uniqueUsers.length > 1) {
       baseUseWith.items.push(
         location.pathname === RoutesConstants.TODO
           ? {


### PR DESCRIPTION
Removing the evaluation allows the 2 option to be shown in the command pallet 