### PR TITLE
intro modal gets invoked in reload of the app, fix #1160

### DIFF
--- a/src/components/Elements/Modal/CustomModal.tsx
+++ b/src/components/Elements/Modal/CustomModal.tsx
@@ -42,18 +42,20 @@ export const DialogTitle = S.StyledTitle
 export const DialogDescription = S.StyledDescription
 export const DialogClose = DialogPrimitive.Close
 
-const CustomDialog = ({
+const CustomDialog = <T extends (...args: any[]) => any>({
   children,
   modalAriaLabel,
   modalTitle,
   open,
   subTitle = undefined,
+  additionalOnClose = undefined,
 }: {
   children: JSX.Element
   modalAriaLabel: string
   modalTitle: string
   open: boolean
   subTitle?: JSX.Element
+  additionalOnClose?: T
 }) => {
   const dispatch = useAppDispatch()
 
@@ -78,6 +80,10 @@ const CustomDialog = ({
             aria-label="close-keyboard-shortcuts-modal"
             onClick={() => {
               if (open) {
+                if (additionalOnClose) {
+                  additionalOnClose()
+                  return
+                }
                 dispatch(setActiveModal(null))
               }
             }}

--- a/src/components/Elements/Modal/CustomModal.tsx
+++ b/src/components/Elements/Modal/CustomModal.tsx
@@ -82,7 +82,6 @@ const CustomDialog = <T extends (...args: any[]) => any>({
               if (open) {
                 if (additionalOnClose) {
                   additionalOnClose()
-                  return
                 }
                 dispatch(setActiveModal(null))
               }

--- a/src/components/Introduction/Introduction.tsx
+++ b/src/components/Introduction/Introduction.tsx
@@ -47,6 +47,7 @@ const Introduction = () => {
       open={activeModal === global.ACTIVE_MODAL_MAP.intro}
       modalTitle={DIALOG_HEADER}
       modalAriaLabel="introduction"
+      additionalOnClose={handleClose}
     >
       <>
         <S.InnerContent>

--- a/src/components/Introduction/Introduction.tsx
+++ b/src/components/Introduction/Introduction.tsx
@@ -35,7 +35,6 @@ const Introduction = () => {
 
   const handleClose = () => {
     updateSettingsLabel({ settingsLabelId, showIntroduction: false })
-    dispatch(setActiveModal(null))
   }
 
   const openKeyboardShortcuts = () => {


### PR DESCRIPTION
Fixed issue where on clicking **cross** button, the modal does not get fully dismissed (appears again on subsequent reloads)