### PR TITLE
fix: Adjust listening to label id on handle history

### DIFF
--- a/src/components/Elements/MessageCount.tsx
+++ b/src/components/Elements/MessageCount.tsx
@@ -26,7 +26,7 @@ const CountWrapper = styled.div`
 
 const IconWrapper = styled.div`
   display: flex;
-  margin: 0 4px;
+  margin: 0 var(--spacing-0-5);
   height: var(--small);
 `
 
@@ -44,31 +44,33 @@ const LengthMessageCount = ({ messages }: IMessages) => {
 
   return (
     <StyledMessageCount>
-      <StyledTooltip
-        title={`${regularCount} ${
-          regularCount > 1 ? MULTI_MESSAGE : SINGLE_MESSAGE
-        }`}
-      >
-        <CountWrapper>
-          {regularCount}
-          <IconWrapper>
-            <QiMail />
-          </IconWrapper>
-        </CountWrapper>
-      </StyledTooltip>
-      {draftCount > 0 && (
+      {regularCount > 0 ? (
+        <StyledTooltip
+          title={`${regularCount} ${
+            regularCount > 1 ? MULTI_MESSAGE : SINGLE_MESSAGE
+          }`}
+        >
+          <CountWrapper>
+            {regularCount}
+            <IconWrapper>
+              <QiMail />
+            </IconWrapper>
+          </CountWrapper>
+        </StyledTooltip>
+      ) : null}
+      {draftCount > 0 ? (
         <StyledTooltip
           title={`${draftCount} ${draftCount > 1 ? MULTI_DRAFT : SINGLE_DRAFT}`}
         >
           <CountWrapper>
-            / {draftCount}
+            {regularCount > 0 ? '/' : null} {draftCount}
             <IconWrapper>
               {' '}
               <FiEdit2 />
             </IconWrapper>
           </CountWrapper>
         </StyledTooltip>
-      )}
+      ) : null}
       &nbsp;&nbsp;—&nbsp;&nbsp;
     </StyledMessageCount>
   )

--- a/src/components/EmailList/RenderEmailList.tsx
+++ b/src/components/EmailList/RenderEmailList.tsx
@@ -115,7 +115,7 @@ const RenderEmailList = ({
   const memoizedThreadList = useMemo(
     () => (
       <S.ThreadList>
-        {threads.length > 0 && (
+        {threads.length > 0 ? (
           <GS.Base>
             <ThreadList
               threads={threads}
@@ -125,12 +125,12 @@ const RenderEmailList = ({
               showLabel={labelIds.includes(global.ARCHIVE_LABEL)}
             />
           </GS.Base>
-        )}
-        {threads.length === 0 && (
+        ) : null}
+        {threads.length === 0 ? (
           <EmptyState>
             <EmailListEmptyStates />
           </EmptyState>
-        )}
+        ) : null}
       </S.ThreadList>
     ),
     [threads, focusedItemIndex]

--- a/src/components/EmailListItem/EmailListItem.tsx
+++ b/src/components/EmailListItem/EmailListItem.tsx
@@ -73,9 +73,10 @@ export const getRecipientName = ({
   emailAddress,
   memoizedDraftOrRegular,
 }: ExtractEmailData) => {
-  const lastMessage = memoizedDraftOrRegular.messages![
-    memoizedDraftOrRegular.messages!.length - 1
-  ]
+  const lastMessage =
+    memoizedDraftOrRegular.messages![
+      memoizedDraftOrRegular.messages!.length - 1
+    ]
   if (lastMessage) {
     return recipientName(lastMessage?.payload?.headers?.to, emailAddress)
   }
@@ -85,9 +86,10 @@ export const getSenderPartial = ({
   emailAddress,
   memoizedDraftOrRegular,
 }: ExtractEmailData) => {
-  const lastMessage = memoizedDraftOrRegular.messages![
-    memoizedDraftOrRegular.messages!.length - 1
-  ]
+  const lastMessage =
+    memoizedDraftOrRegular.messages![
+      memoizedDraftOrRegular.messages!.length - 1
+    ]
   if (lastMessage) {
     return senderNamePartial(lastMessage?.payload?.headers?.from, emailAddress)
   }
@@ -97,9 +99,10 @@ export const getSenderFull = ({
   emailAddress,
   memoizedDraftOrRegular,
 }: ExtractEmailData) => {
-  const lastMessage = memoizedDraftOrRegular.messages![
-    memoizedDraftOrRegular.messages!.length - 1
-  ]
+  const lastMessage =
+    memoizedDraftOrRegular.messages![
+      memoizedDraftOrRegular.messages!.length - 1
+    ]
   if (lastMessage) {
     return senderNameFull(lastMessage?.payload?.headers?.from, emailAddress)
   }
@@ -109,9 +112,10 @@ export const getSenderFull = ({
 const getSubject = ({
   memoizedDraftOrRegular,
 }: Pick<ExtractEmailData, 'memoizedDraftOrRegular'>) => {
-  const lastMessage = memoizedDraftOrRegular.messages![
-    memoizedDraftOrRegular.messages!.length - 1
-  ]
+  const lastMessage =
+    memoizedDraftOrRegular.messages![
+      memoizedDraftOrRegular.messages!.length - 1
+    ]
   if (lastMessage) {
     return emailSubject(lastMessage?.payload?.headers?.subject)
   }
@@ -120,9 +124,10 @@ const getSubject = ({
 const getSnippet = ({
   memoizedDraftOrRegular,
 }: Pick<ExtractEmailData, 'memoizedDraftOrRegular'>) => {
-  const lastMessage = memoizedDraftOrRegular.messages![
-    memoizedDraftOrRegular.messages!.length - 1
-  ]
+  const lastMessage =
+    memoizedDraftOrRegular.messages![
+      memoizedDraftOrRegular.messages!.length - 1
+    ]
   if (lastMessage) {
     return emailSnippet(lastMessage)
   }

--- a/src/components/MainHeader/Navigation/Navigation.tsx
+++ b/src/components/MainHeader/Navigation/Navigation.tsx
@@ -75,7 +75,7 @@ const Navigation = () => {
     modifierKey: keyConstants.KEY_SPECIAL.shift,
     key: keyConstants.KEY_LETTERS.c,
     isDisabled:
-      (inSearch || !!activeModal) &&
+      (inSearch || !!activeModal || location.pathname.startsWith('/mail/')) &&
       (location.pathname.includes('compose') || isReplying || isForwarding),
   })
 

--- a/src/store/emailListSlice.ts
+++ b/src/store/emailListSlice.ts
@@ -497,12 +497,13 @@ export const loadEmailDetails =
   (emailListObjectArray: Array<TEmailListObject>): AppThunk =>
   (dispatch, getState) => {
     const { storageLabels } = getState().labels
+    // TODO: Introduce filtering on historyId, to understand which emails are new to the system and update the system for that.
     emailListObjectArray.forEach((labeledThreads) => {
       const { threads, labels, nextPageToken } = labeledThreads
       if (threads.length > 0) {
         const lastMessage = threads[0]?.messages[threads[0].messages.length - 1]
         if (lastMessage && lastMessage.labelIds.includes(global.DRAFT_LABEL)) {
-          const labelNames = threads[0]?.messages[0]?.labelIds
+          const labelNames = lastMessage?.labelIds
           if (labelNames) {
             const legalLabels = onlyLegalLabelObjects({
               storageLabels,


### PR DESCRIPTION
## Related Issue

Closes: #1204 

### Describe the changes you've made

1. Updated the functioning of the message count - it will only show message count when there are messages, and the slash when there is a message count.
2. Fixed listening to the History object

## How has this been tested?

1. User testing

## Checklist

<!--
Example how to mark a checkbox:-
- [x] I have performed a self-review of my own code.
-->

- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] I have followed the code style of the project
- [x] I have tested my code, and it works without errors

## Additional Information

<!-- Screenshots, notes for reviewers, anything? -->

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/Elysium-Labs-EU/juno-core/blob/dev/CODE_OF_CONDUCT.md)
