### PR TITLE
fix: Open list view on multiple drafts

### DIFF
--- a/src/components/EmailOptions/ReplyOverview.ts
+++ b/src/components/EmailOptions/ReplyOverview.ts
@@ -9,7 +9,7 @@ interface IReplyOverview {
 
 const ReplyOverview = ({ id, dispatch }: IReplyOverview) => {
   dispatch(setIsReplying(true))
-  dispatch(openEmail({ id }))
+  dispatch(openEmail({ id, isReplying: true }))
 }
 
 export default ReplyOverview


### PR DESCRIPTION
## Related Issue

Closes: #1210 

### Describe the changes you've made

1. On opening of the draft, we check how many draft messages there are. More than 1 will open up the regular email detail view.

## How has this been tested?

1. User testing

## Checklist

<!--
Example how to mark a checkbox:-
- [x] I have performed a self-review of my own code.
-->

- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] I have followed the code style of the project
- [x] I have tested my code, and it works without errors

## Additional Information

<!-- Screenshots, notes for reviewers, anything? -->

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/Elysium-Labs-EU/juno-core/blob/dev/CODE_OF_CONDUCT.md)
